### PR TITLE
Update for macOSX to build and run as a bundle.

### DIFF
--- a/Source/ZXSpectrum/CMakeLists.txt
+++ b/Source/ZXSpectrum/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required (VERSION 3.10)
 
 project (SpectrumAnalyser)
 
+set(APP_NAME SpectrumAnalyser)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_package(OpenGL REQUIRED)
 	find_package(Threads REQUIRED)
@@ -13,6 +15,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
+	set(MACOSX_BUNDLE_BUNDLE_NAME SpectrumAnalyser)
 	find_package(OpenGL REQUIRED)
 	find_package(Threads REQUIRED)
 	find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
@@ -122,7 +126,7 @@ else()
 	set ( platform_main Windows/WinMain.cpp )
 endif()
 
-add_executable (SpectrumAnalyser ${shared_src} ${program_src} ${platform_main} ${vendor_src} )
+add_executable (SpectrumAnalyser MACOSX_BUNDLE ${shared_src} ${program_src} ${platform_main} ${vendor_src} )
 
 # This is to make the filter folders in Visual Studio, we need cmake 3.10 for this
 source_group( TREE ${CMAKE_CURRENT_SOURCE_DIR}/${vendor_dir} PREFIX Vendor FILES ${vendor_src} )
@@ -178,4 +182,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 		${CMAKE_DL_LIBS}
 		${AUDIOTOOLBOX_LIBRARY}
 		)
+	install(TARGETS ${APP_NAME}
+		BUNDLE DESTINATION . COMPONENT RunTime
+		RUNTIME DESTINATION bin COMPONENT RunTime
+		)
+	add_custom_command(TARGET ${APP_NAME} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		${CMAKE_CURRENT_SOURCE_DIR}/../../Data/SpectrumAnalyser/imgui.ini
+		$<TARGET_FILE_DIR:${APP_NAME}>
+		)
+	set(APPS "\${CMAKE_INSTALL_PREFIX}/${APP_NAME}.app")
+	set(LIBS )
+	set(DIRS ${CMAKE_BINARY_DIR})
+	install(CODE "include(BundleUtilities)
+	fixup_bundle(\"${APPS}\" \"${LIBS}\" \"${DIRS}\")")
+	set(CPACK_GENERATOR "DRAGNDROP")
+	include(CPack)
 endif()

--- a/Source/ZXSpectrum/GLFW/GLFWMain.cpp
+++ b/Source/ZXSpectrum/GLFW/GLFWMain.cpp
@@ -3,6 +3,12 @@
 // If you are new to Dear ImGui, read documentation from the docs/ folder + read the top of imgui.cpp.
 // Read online: https://github.com/ocornut/imgui/tree/master/docs
 
+#if __APPLE__
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <string>
+#endif
+
 #include "imgui.h"
 #include <implot.h>
 #include <backends/imgui_impl_glfw.h>
@@ -91,6 +97,25 @@ int main(int argc, char** argv)
     ImGui::CreateContext();
     ImPlot::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
+
+#if __APPLE__
+    char buf [PATH_MAX];
+    uint32_t bufsize = PATH_MAX;
+    if(!_NSGetExecutablePath(buf, &bufsize))
+    {
+	    std::string ini_location(buf);
+	    int last_dir = ini_location.find_last_of('/');
+	    if(last_dir != std::string::npos)
+	    {
+        ini_location.resize(last_dir);
+        ini_location.append("/imgui.ini");
+        strcpy(buf, ini_location.c_str());
+        io.IniFilename = buf;
+      }
+    }
+#endif
+
+
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking


### PR DESCRIPTION
 * Update CMake config to build fat binary, arm64 and x86_64.
 * Update CMake to include a bundle/install step.
 * Update macOSX runtime to find the imgui.ini in the same location in the bundle as the executable.