### PR TITLE
MacOS path handling fixes

### DIFF
--- a/Source/Shared/Misc/GlobalConfig.h
+++ b/Source/Shared/Misc/GlobalConfig.h
@@ -30,5 +30,13 @@ struct FGlobalConfig
 protected:
 	virtual void ReadFromJson(const nlohmann::json& jsonConfigFile);
 	virtual void WriteToJson(nlohmann::json& jsonConfigFile) const;
-};
 
+	// Ensure that paths have a trailing slash.
+	void fixupPaths(void)
+	{
+		if (WorkspaceRoot.back() != '/')
+			WorkspaceRoot += "/";
+		if (SnapshotFolder.back() != '/')
+			SnapshotFolder += "/";
+	}
+};

--- a/Source/ZXSpectrum/ZXSpectrumConfig.cpp
+++ b/Source/ZXSpectrum/ZXSpectrumConfig.cpp
@@ -5,15 +5,18 @@
 
 bool FZXSpectrumConfig::Init(void)
 {
-    if(FGlobalConfig::Init() == false)
-        return false;
-    
-    SnapshotFolder = GetDocumentsPath("SpectrumGames/48K");
-    SnapshotFolder128 = GetDocumentsPath("SpectrumGames/128K");
-    WorkspaceRoot = GetDocumentsPath("SpectrumAnalyserProjects");
-    
-    return true;
+	if(FGlobalConfig::Init() == false)
+		return false;
+
+	SnapshotFolder = GetDocumentsPath("SpectrumGames/48K");
+	SnapshotFolder128 = GetDocumentsPath("SpectrumGames/128K");
+	WorkspaceRoot = GetDocumentsPath("SpectrumAnalyserProjects");
+
+	fixupPaths();
+
+	return true;
 }
+
 void FZXSpectrumConfig::ReadFromJson(const nlohmann::json& jsonConfigFile)
 {
 	FGlobalConfig::ReadFromJson(jsonConfigFile);
@@ -25,13 +28,7 @@ void FZXSpectrumConfig::ReadFromJson(const nlohmann::json& jsonConfigFile)
 	if (jsonConfigFile.contains("RZXFolder"))
 		RZXFolder = jsonConfigFile["RZXFolder"];
 
-	// fixup paths
-	if (SnapshotFolder128.back() != '/')
-		SnapshotFolder128 += "/";
-	if (PokesFolder.back() != '/')
-		PokesFolder += "/";
-	if (RZXFolder.back() != '/')
-		RZXFolder += "/";
+	fixupPaths();
 }
 
 void FZXSpectrumConfig::WriteToJson(nlohmann::json& jsonConfigFile) const

--- a/Source/ZXSpectrum/ZXSpectrumConfig.h
+++ b/Source/ZXSpectrum/ZXSpectrumConfig.h
@@ -14,4 +14,20 @@ protected:
 
 	void ReadFromJson(const nlohmann::json& jsonConfigFile) override;
 	void WriteToJson(nlohmann::json& jsonConfigFile) const override;
+
+private:
+
+	// Ensure that paths have a trailing slash.
+	void fixupPaths(void)
+	{
+		FGlobalConfig::fixupPaths();
+
+		if (SnapshotFolder128.back() != '/')
+			SnapshotFolder128 += "/";
+		if (PokesFolder.back() != '/')
+			PokesFolder += "/";
+		if (RZXFolder.back() != '/')
+			RZXFolder += "/";
+	}
+
 };


### PR DESCRIPTION
The MacOS build of SA was starting up in a weird state for me.

First I found that it was creating `SpectrumAnalyserProjectsChaseHQ` and not `SpectrumAnalyserProjects/ChaseHQ` due to missing trailing slashes. First commit hopefully fixes that.

Second I found that it was failing to copy the `imgui.ini` file across to `~/Library/Application Support/org.colourclash.Spectrum Analyser` because that directory was missing. The second commit reworks the path handling, reactivating and updating the commented-out code which creates the directory. It also stashes path results in local statics before returning them.

