### PR TITLE
Clean up some .gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@
 /Source/CPC/build
 /Source/CPC/linuxbuild
 /Data/CPCAnalyser/GlobalConfig.json
+.vscode
+build


### PR DESCRIPTION
When opening the project root in VSCode on MacOS and building etc there are a load of temp files not filtered out. I've added a few lines to the .gitignore to fix.