### PR TITLE
Fix hang due to stack imbalance in DrawOSBHandlersComboBox

### DIFF
--- a/Source/Shared/LuaScripting/LuaSys.cpp
+++ b/Source/Shared/LuaScripting/LuaSys.cpp
@@ -289,7 +289,10 @@ void DrawOSBHandlersComboBox(std::string& HandlerName)
 
 	lua_getglobal(pState, kOSBHandlersTable);
 	if (lua_istable(pState, -1) == false)
+	{
+		lua_pop(pState, 1);	// balance stack
 		return;
+	}
 
 	if(ImGui::BeginCombo("OSB Handlers", HandlerName.c_str()))
 	{


### PR DESCRIPTION
Small change to fix the stack imbalance in `DrawOSBHandlersComboBox` - prevents the application from hanging due to the Lua console filling up with stack dumps.