### PR TITLE
Assembler exporter functionality

### DIFF
--- a/Source/CPC/CPCAsmExporter.cpp
+++ b/Source/CPC/CPCAsmExporter.cpp
@@ -1,0 +1,68 @@
+#include "CodeAnalyser/AssemblerExport.h"
+#include "CPCEmu.h"
+
+class FCPCAsmExporterBase : public FASMExporter
+{
+public:
+	void ProcessLabelsOutsideExportedRange(void) override
+	{
+		FCodeAnalysisState& state = pEmulator->GetCodeAnalysis();
+
+		SetOutputToHeader();
+
+		Output("\n; RAM Labels\n");
+
+		for (auto labelAddr : DasmState.LabelsOutsideRange)
+		{
+			const FLabelInfo* pLabelInfo = state.GetLabelForPhysicalAddress(labelAddr);
+			if (labelAddr >= 0x0000)
+				Output("%s: \t%s %s\n", pLabelInfo->GetName(), Config.EQUText, NumStr(labelAddr));
+		}
+
+		Output("\n");
+	}
+};
+
+class FSJasmPlusCPCExporter : public FCPCAsmExporterBase
+{
+public:
+	FSJasmPlusCPCExporter()
+	{
+		Config.DataBytePrefix = "db";
+		Config.DataWordPrefix = "dw";
+		Config.DataTextPrefix = "db";
+		Config.ORGText = "\torg";
+		Config.EQUText = "equ";
+		Config.LocalLabelPrefix = ".";
+	}
+
+	void AddHeader(void) override
+	{
+		FCPCEmu* pCPCEmu = static_cast<FCPCEmu*>(pEmulator);
+		if (pCPCEmu && pCPCEmu->CPCEmuState.type == CPC_TYPE_6128)
+			Output("\tDEVICE AMSTRADCPC6128\n");
+		else
+			Output("\tDEVICE AMSTRADCPC464\n");
+	}
+};
+
+class FMaxamExporter : public FCPCAsmExporterBase
+{
+public:
+	FMaxamExporter()
+	{
+		Config.DataBytePrefix = "defb";
+		Config.DataWordPrefix = "defw";
+		Config.DataTextPrefix = "defm";
+		Config.ORGText = "org";
+		Config.EQUText = "equ";
+		Config.LocalLabelPrefix = ".";
+	}
+};
+
+bool InitCPCAsmExporters(FCPCEmu* pCPCEmu)
+{
+	AddAssemblerExporter("SJasmPlus", new FSJasmPlusCPCExporter);
+	AddAssemblerExporter("Maxam", new FMaxamExporter);
+	return true;
+}

--- a/Source/CPC/CPCEmu.cpp
+++ b/Source/CPC/CPCEmu.cpp
@@ -28,6 +28,7 @@
 #include "CodeAnalyser/UI/OverviewViewer.h"
 
 #include <sokol_audio.h>
+
 #include "cpc-roms.h"
 
 #include <ImGuiSupport/ImGuiTexture.h>
@@ -37,6 +38,8 @@
 #include "LuaScripting/LuaSys.h"
 #include "CPCLuaAPI.h"
 #include "SnapshotLoaders/SNALoader.h"
+
+bool InitCPCAsmExporters(FCPCEmu* pCPCEmu);
 
 #define EXPORT_ROM_ANALYSIS_JSON 0
 #define ENABLE_EXTERNAL_ROM_SUPPORT 0
@@ -997,6 +1000,8 @@ bool FCPCEmu::Init(const FEmulatorLaunchConfig& launchConfig)
 	debugger.RegisterEventType((int)EEventType::UpperROMSelect, "Upper ROM Select", 0xff3f0c90, IOPortEventShowAddress, UpperROMSelectShowValue);
 
 	pMemoryAnalyser->SetScreenMemoryArea(Screen.GetScreenPage(), Screen.GetScreenMemSize());
+
+	InitCPCAsmExporters(this);
 
 #ifndef NDEBUG
 	LOGINFO("Init CPCEmu...Done");


### PR DESCRIPTION
Added assembly exporter to CPC Analyzer. It allows for the selection of Sjasmplus or Maxam under Options/Assembler Exporter. The options under File for Export ASM File and Export ASM Range will then create asm files.